### PR TITLE
Feature/ot111 84 - Agregar documentación con Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ Password para todos los usuarios administradores y usuarios regulares:
     user10@mail.com
 
 
+### OpenApi 3.0 - Swagger documentation:
+#### La descripcion de OpenAPI esta disponible en la ruta:
+
+[http://localhost:8080/api/docs](http://localhost:8080/api/docs)
+
+###La documentacion de la API con Swagger-UI esta disponible en la ruta:
+
+[http://localhost:8080/api/docs/swagger-ui/](http://localhost:8080/api/docs/swagger-ui/)

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.5.13'
 }
 
 test {

--- a/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
@@ -35,6 +35,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers("/auth/login").permitAll()
                 .antMatchers("/auth/register").permitAll()
+                .antMatchers("/api/docs/**").permitAll()
                 // TODO: Add Routes / Roles
                 .antMatchers("/users").hasRole("ADMIN")
                 .antMatchers("/test/auth").authenticated()

--- a/src/main/java/com/alkemy/ong/auth/controller/UserAuthController.java
+++ b/src/main/java/com/alkemy/ong/auth/controller/UserAuthController.java
@@ -6,6 +6,13 @@ import com.alkemy.ong.model.request.security.AuthenticationRequest;
 import com.alkemy.ong.model.request.security.RegisterRequest;
 import com.alkemy.ong.model.response.security.AuthenticationResponse;
 import com.alkemy.ong.model.response.security.RegisterResponse;
+import com.alkemy.ong.model.response.user.UserDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,12 +34,26 @@ public class UserAuthController {
     private UserAuthService userAuthServ;
 
     // Signup
+    @Operation(summary = "Register (and login) a new user.",description = "Register a new user in system, login, and send mail confirmation")
+    @ApiResponses(
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "User registered successfully",
+                    content = {@Content(mediaType = "application/json"
+                            )}))
     @PostMapping("/register")
     public ResponseEntity<RegisterResponse> signUp(@Valid @RequestBody RegisterRequest userToCreate) {
         RegisterResponse userResponse = userDetailsCustomService.signupUser(userToCreate);
         return ResponseEntity.status(HttpStatus.CREATED).body(userResponse);
     }
 
+    @Operation(summary = "User Login with email and password.",description = "Login a previously registered user with email and password in system")
+    @ApiResponses(
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User logged in successfully",
+                    content = {@Content(mediaType = "application/json"
+                    )}))
     @PostMapping("/login")
     public ResponseEntity<Object> login(@RequestBody AuthenticationRequest authenticationRequest) throws Exception {
         AuthenticationResponse userDetails = userAuthServ.loginAttempt(authenticationRequest);

--- a/src/main/java/com/alkemy/ong/config/OpenApiConfig.java
+++ b/src/main/java/com/alkemy/ong/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.alkemy.ong.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "My API", version = "v1"))
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        bearerFormat = "JWT",
+        scheme = "bearer"
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/alkemy/ong/controller/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controller/OrganizationController.java
@@ -16,6 +16,7 @@ class OrganizationController {
     @Autowired
     private OrganizationService organizationService;
 
+
     @GetMapping("/{id}/public")
     public ResponseEntity<OrganizationDTO> getOrganization(@PathVariable Long id) {
         return ResponseEntity.ok(OrganizationDTO.buildPublicData(organizationService.readOrganization(id)));

--- a/src/main/java/com/alkemy/ong/controller/UserController.java
+++ b/src/main/java/com/alkemy/ong/controller/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
                     responseCode = "200",
                     description = "All users retrieved",
                     content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = UserDTO.class))}),
+                            schema = @Schema(implementation = UserDTO.class))}),//UserDTO or UserEntity??
             @ApiResponse(
                     responseCode = "403",
                     description = "Access Denied, authorization needed",

--- a/src/main/java/com/alkemy/ong/controller/UserController.java
+++ b/src/main/java/com/alkemy/ong/controller/UserController.java
@@ -26,16 +26,16 @@ public class UserController {
     @Autowired
     private UserService userService;
 
-    @Operation(summary = "Obtener todos los usuarios.", security = @SecurityRequirement(name = "bearerAuth"),description = "Obtener lista completa de usuarios, solo accesible por administrador")
+    @Operation(summary = "Get all users.", security = @SecurityRequirement(name = "bearerAuth"),description = "Get full list of users in database, only accesible by an Administrator")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "Se obtuvieron todos los usuarios en el sistema",
+                    description = "All users retrieved",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = UserDTO.class))}),
             @ApiResponse(
                     responseCode = "403",
-                    description = "Acceso denegado",
+                    description = "Access Denied, authorization needed",
                     content = @Content)})
     @GetMapping
     public ResponseEntity<List<UserDTO>> getAllUsers() {

--- a/src/main/java/com/alkemy/ong/controller/UserController.java
+++ b/src/main/java/com/alkemy/ong/controller/UserController.java
@@ -1,13 +1,21 @@
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.model.entity.UserEntity;
 import com.alkemy.ong.model.response.user.UserDTO;
 import com.alkemy.ong.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
@@ -19,11 +27,22 @@ public class UserController {
     @Autowired
     private UserService userService;
 
+    @Operation(summary = "Obtener todos los usuarios.", security = @SecurityRequirement(name = "bearerAuth"),description = "Obtener lista completa de usuarios, solo accesible por administrador")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Se obtuvieron todos los usuarios en el sistema",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = UserDTO.class))}),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Acceso denegado",
+                    content = @Content)})
     @GetMapping
     public ResponseEntity<List<UserDTO>> getAllUsers() {
         return new ResponseEntity<>(userService.findAllUsers(), HttpStatus.OK);
     }
 }
 
-//TODO Pull Request para agregar Path /users en SecurityConfiguration para que lo pueda solo trabajar un admin
+
 

--- a/src/main/java/com/alkemy/ong/controller/UserController.java
+++ b/src/main/java/com/alkemy/ong/controller/UserController.java
@@ -15,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,16 @@ spring:
 
 sendgrid:
     welcome-template: d-6d059c03a1dd4b2aa22e9ae894138844
+
+
+#Swagger Configurations
+springdoc:
+    api-docs:
+        path: /api/docs #path para consultar springdoc-openapi doc
+    swagger-ui:
+            path: /api/docs/swagger-ui.html # path para consultar swagger-ui
+            enabled: true #para produccion conviene desactivar swagger-ui (o trabajarla en otro puerto)
+    # Packages to include:
+    packagesToScan: com.alkemy.ong.controller, com.alkemy.ong.auth.controller #Separamos los paquetes a incluir con una coma
+    # Paths to include:
+    pathsToMatch: /users/**, /auth/** #Separamos los paths a incluir con una coma


### PR DESCRIPTION
#### Link JIRA: https://alkemy-labs.atlassian.net/browse/OT111-84

#### - Se agrego la dependencia springdoc-openapi-ui a Gradle
#### - Se agregaron configuraciones de Swagger en application.yml:

1.  Se modificaron los paths por defecto de para que se pueda consultar en `/api/docs`
2. Por el momento solo se incluyeron los packages y paths de controlador de User y de Autorización de usuarios (register y login) 

#### -  Se agrego el path `/api/docs` en SecurityConfiguration para ser de libre acceso.

#### - Se creo la clase de configuración OpenApiConfig para activar bearerAuth en la interfaz de Swagger-UI

#### - Se agregaron las anotaciones correspondientes en UserController y en UserAuthController para configurar los mensajes de respuesta, descripciones y activar autorización con bearer token.

#### - Se actualizo el Readme con los paths para poder acceder a la documentación.
