### PR TITLE
OT111-46 - Endpoint creación de novedades.

### DIFF
--- a/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
@@ -44,6 +44,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET,"/categories").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE, "/categories/{id}").hasRole("ADMIN")
                 .antMatchers(HttpMethod.PUT, "/categories/{id}").hasRole("ADMIN")
+                .antMatchers(HttpMethod.POST, "/news").hasRole("ADMIN")
                 .antMatchers("/api/docs/**").permitAll()
                 .anyRequest().authenticated()
                 .and().exceptionHandling()

--- a/src/main/java/com/alkemy/ong/controller/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controller/NewsController.java
@@ -1,0 +1,41 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.model.request.CategoryRequestDTO;
+import com.alkemy.ong.model.request.NewsRequestDTO;
+import com.alkemy.ong.model.response.CategoryResponseDTO;
+import com.alkemy.ong.model.response.news.NewsResponseDTO;
+import com.alkemy.ong.service.NewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("news")
+@RequiredArgsConstructor
+@Tag(name = "Noticias")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    @PostMapping
+    @Operation(summary = "Crear nueva noticia")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Noticia creada",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NewsResponseDTO.class))})
+    })
+    public ResponseEntity<NewsResponseDTO> createNewNews(@RequestBody NewsRequestDTO request) {
+        NewsResponseDTO response = newsService.saveNews(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/alkemy/ong/model/entity/NewsEntity.java
+++ b/src/main/java/com/alkemy/ong/model/entity/NewsEntity.java
@@ -1,7 +1,6 @@
 package com.alkemy.ong.model.entity;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -10,10 +9,12 @@ import javax.validation.constraints.NotEmpty;
 import java.time.OffsetDateTime;
 import com.alkemy.ong.model.entity.CategoryEntity;
 
-@Getter
-@Setter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 @Table(name = "news") //Both singular and plural of "news" word it's the same.
 @Entity
+@Builder
 @SQLDelete(sql = "UPDATE news SET deleted = true WHERE id=?")
 @Where(clause = "deleted = false")
 public class NewsEntity {
@@ -34,7 +35,8 @@ public class NewsEntity {
     @JoinColumn(name = "category_id")
     private CategoryEntity categoryId;
 
-    private OffsetDateTime createdDate;
+    @Builder.Default
+    private OffsetDateTime createdDate = OffsetDateTime.now();
 
     private OffsetDateTime modifiedDate;
 

--- a/src/main/java/com/alkemy/ong/model/mapper/CategoryMapper.java
+++ b/src/main/java/com/alkemy/ong/model/mapper/CategoryMapper.java
@@ -10,6 +10,7 @@ public class CategoryMapper {
 
     public CategoryEntity categoryDTO2Entity(CategoryRequestDTO dto) {
         CategoryEntity ent = new CategoryEntity();
+        ent.setId(dto.getId());
         ent.setName(dto.getName());
         ent.setDescription(dto.getDescription());
         ent.setImage(dto.getImage());

--- a/src/main/java/com/alkemy/ong/model/mapper/NewsMapper.java
+++ b/src/main/java/com/alkemy/ong/model/mapper/NewsMapper.java
@@ -1,0 +1,58 @@
+package com.alkemy.ong.model.mapper;
+
+import com.alkemy.ong.model.entity.NewsEntity;
+import com.alkemy.ong.model.request.NewsRequestDTO;
+import com.alkemy.ong.model.response.news.NewsResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.NoSuchElementException;
+
+@Component
+@RequiredArgsConstructor
+public class NewsMapper {
+
+    private final CategoryMapper mapper;
+
+    public NewsResponseDTO entity2DTO(NewsEntity entity) {
+        if (entity == null){return null;}
+        return NewsResponseDTO.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .content(entity.getContent())
+                .image(entity.getImage())
+                .categoryResponseDTO(mapper.categoryEntity2DTO(entity.getCategoryId()))
+                .createdDate(entity.getCreatedDate())
+                .createdBy(entity.getCreatedBy())
+                .modifiedDate(entity.getModifiedDate())
+                .modifiedBy(entity.getModifiedBy())
+                .build();
+    }
+
+    public NewsEntity dto2Entity(NewsRequestDTO dto) {
+        if (dto == null){return null;}
+
+        NewsEntity entity = new NewsEntity();
+        if (dto.getName() != null){
+            entity.setName(dto.getName());
+        } else {throw new NoSuchElementException("'Nombre' no puede estar vacío.");}
+        if (dto.getContent() != null){
+            entity.setContent(dto.getContent());
+        } else {throw new NoSuchElementException("'Contenido' no puede estar vacío.");}
+        if (dto.getImage() != null){
+            entity.setImage(dto.getImage());
+        } else {throw new NoSuchElementException("'Imagen' no puede estar vacío.");}
+        if (dto.getCategoryRequestDTO() != null){
+            entity.setCategoryId(mapper.categoryDTO2Entity(dto.getCategoryRequestDTO()));
+        } else {throw new NoSuchElementException("'Categoría' no puede estar vacío.");}
+            entity.setModifiedBy(dto.getModifiedBy());
+
+        return entity;
+    }
+
+    public NewsResponseDTO buildToList(NewsEntity entity){
+        return NewsResponseDTO.builder()
+                .name(entity.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/alkemy/ong/model/request/CategoryRequestDTO.java
+++ b/src/main/java/com/alkemy/ong/model/request/CategoryRequestDTO.java
@@ -9,6 +9,8 @@ import javax.validation.constraints.NotEmpty;
 @Setter
 public class CategoryRequestDTO {
 
+    private Long id;
+
     @NotEmpty(message = "El nombre es obligatorio")
     private String name;
 

--- a/src/main/java/com/alkemy/ong/model/request/NewsRequestDTO.java
+++ b/src/main/java/com/alkemy/ong/model/request/NewsRequestDTO.java
@@ -1,0 +1,21 @@
+package com.alkemy.ong.model.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class NewsRequestDTO {
+
+    private Long id;
+
+    private String name;
+
+    private String content;
+
+    private String image;
+
+    private CategoryRequestDTO categoryRequestDTO;
+
+    private String modifiedBy;
+}

--- a/src/main/java/com/alkemy/ong/model/response/news/NewsResponseDTO.java
+++ b/src/main/java/com/alkemy/ong/model/response/news/NewsResponseDTO.java
@@ -1,0 +1,30 @@
+package com.alkemy.ong.model.response.news;
+
+import com.alkemy.ong.model.response.CategoryResponseDTO;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Builder
+@Data
+public class NewsResponseDTO {
+
+    private Long id;
+
+    private String name;
+
+    private String content;
+
+    private String image;
+
+    private CategoryResponseDTO categoryResponseDTO;
+
+    private OffsetDateTime createdDate;
+
+    private OffsetDateTime modifiedDate;
+
+    private String createdBy;
+
+    private String modifiedBy;
+}

--- a/src/main/java/com/alkemy/ong/service/NewsService.java
+++ b/src/main/java/com/alkemy/ong/service/NewsService.java
@@ -1,0 +1,9 @@
+package com.alkemy.ong.service;
+
+import com.alkemy.ong.model.request.NewsRequestDTO;
+import com.alkemy.ong.model.response.news.NewsResponseDTO;
+
+public interface NewsService {
+
+    NewsResponseDTO saveNews(NewsRequestDTO request);
+}

--- a/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
@@ -1,0 +1,33 @@
+package com.alkemy.ong.service.impl;
+
+import com.alkemy.ong.model.entity.CategoryEntity;
+import com.alkemy.ong.model.entity.NewsEntity;
+import com.alkemy.ong.model.mapper.CategoryMapper;
+import com.alkemy.ong.model.mapper.NewsMapper;
+import com.alkemy.ong.model.request.NewsRequestDTO;
+import com.alkemy.ong.model.response.news.NewsResponseDTO;
+import com.alkemy.ong.repository.CategoryRepository;
+import com.alkemy.ong.repository.NewsRepository;
+import com.alkemy.ong.service.NewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NewsServiceImpl implements NewsService {
+
+    private final NewsRepository newsRepository;
+    private final CategoryRepository categoryRepository;
+    private final NewsMapper newsMapper;
+    private final CategoryMapper categoryMapper;
+
+    @Override
+    public NewsResponseDTO saveNews(NewsRequestDTO request) {
+        NewsEntity newsEntity = newsMapper.dto2Entity(request);
+        CategoryEntity categoryEntity;
+        categoryEntity = categoryMapper.categoryDTO2Entity(request.getCategoryRequestDTO());
+        newsEntity.setCategoryId(categoryRepository.getById(categoryEntity.getId()));
+        NewsEntity newsSaved = newsRepository.save(newsEntity);
+        return newsMapper.entity2DTO(newsSaved);
+    }
+}


### PR DESCRIPTION
### **OT111-46 - Endpoint creación de novedades**

**LINK JIRA:**
https://alkemy-labs.atlassian.net/jira/software/c/projects/OT111/boards/168?modal=detail&selectedIssue=OT111-46

_Se crearon las siguientes clases/interfaces:_

- NewsResponseDTO
- NewsRequestDTO
- NewsMapper
- NewsService
- NewsServiceImpl
- NewsController

La tarea requería lo siguiente:
**"COMO usuario administrador"**: se agregó la ruta al security config.
**POST /news**: Se creó el endpoint de tipo post con las anotaciones de la última actualización de develop, además se crearon los métodos en el service y la implementacion del mismo.
**Deberá validar la existencia de los campos enviados**: se validaron los datos en el mapper para usarlo cada vez que se requiera, usando las excepciones.
**Antes de almacenarla, deberá asignarle la columna type con el valor "news".**: Se setea en el método de la implementación la busqueda de la categoría correspondiente, ya que en caso contrario devuelve null. 

NOTAS: 
Debo reveer si la última consigna está bien implementada, ya que no se entendía muy bien lo que se necesitaba. Cuando tengas un tiempo libre Osvaldo lo vemos si está mal.

![1](https://user-images.githubusercontent.com/90858496/145750041-07e24df5-64e1-4f27-a2c6-f4740a744593.jpeg)
![2](https://user-images.githubusercontent.com/90858496/145750042-087fa79d-016b-4725-be8c-eee790c521bb.jpg)

