### PR TITLE
Feature/ot111 80 - Agregar paginación a Categorías

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/CategoryController.java
+++ b/src/main/java/com/alkemy/ong/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.controller;
 
 import com.alkemy.ong.model.request.CategoryRequestDTO;
 import com.alkemy.ong.model.response.CategoryResponseDTO;
+import com.alkemy.ong.model.response.pagination.CustomPage;
 import com.alkemy.ong.service.CategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,11 +11,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/categories")
@@ -40,9 +49,18 @@ public class CategoryController {
     }
 
     @GetMapping
-    @Operation(summary = "Lista todas las categorías")
-    public ResponseEntity<List<CategoryResponseDTO>> getCategories() {
-        var response = categoryService.getCategories();
+    @Operation(summary = "Lista todas las categorías",
+            description = "Obtiene todas las categorías, con un tamaño por defecto de pagina de 10 elementos, " +
+                    "ademas retorna el numero de pagina, cantidad de elementos en la pagina, cantidad de elementos total y " +
+                    "cantidad total de paginas")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomPage.class))})})
+    public ResponseEntity<CustomPage<CategoryResponseDTO>> getCategoriesPage(@RequestParam(value = "page", required = false, defaultValue = "0") int page,
+                                                                             @RequestParam(value = "size", required = false, defaultValue = "10") int size) {
+        Pageable pageRequest = PageRequest.of(page, size);
+        var response = categoryService.getCategoriesPageable(pageRequest);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/alkemy/ong/model/response/pagination/CustomPage.java
+++ b/src/main/java/com/alkemy/ong/model/response/pagination/CustomPage.java
@@ -1,0 +1,24 @@
+package com.alkemy.ong.model.response.pagination;
+
+
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+public class CustomPage<T> {
+
+    List<T> content;
+
+    CustomPageable pageable;
+
+    public CustomPage(Page<T> page) {
+        this.content = page.getContent();
+        this.pageable = new CustomPageable(
+                page.getPageable().getPageNumber(),
+                page.getNumberOfElements(),
+                page.getTotalElements(),
+                page.getTotalPages());
+    }
+}

--- a/src/main/java/com/alkemy/ong/model/response/pagination/CustomPageable.java
+++ b/src/main/java/com/alkemy/ong/model/response/pagination/CustomPageable.java
@@ -1,0 +1,15 @@
+package com.alkemy.ong.model.response.pagination;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CustomPageable {
+
+    private int pageNumber;
+    private int numberOfElements;
+    private long totalElements;
+    private int totalPages;
+
+}

--- a/src/main/java/com/alkemy/ong/service/CategoryService.java
+++ b/src/main/java/com/alkemy/ong/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.alkemy.ong.service;
 
 import com.alkemy.ong.model.request.CategoryRequestDTO;
 import com.alkemy.ong.model.response.CategoryResponseDTO;
+import com.alkemy.ong.model.response.pagination.CustomPage;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -16,4 +18,6 @@ public interface CategoryService {
     void deleteCategory(Long id);
 
     List<CategoryResponseDTO> getCategories();
+
+    CustomPage<CategoryResponseDTO> getCategoriesPageable(Pageable pageable);
 }

--- a/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CategoryServiceImpl.java
@@ -4,9 +4,11 @@ import com.alkemy.ong.model.entity.CategoryEntity;
 import com.alkemy.ong.model.mapper.CategoryMapper;
 import com.alkemy.ong.model.request.CategoryRequestDTO;
 import com.alkemy.ong.model.response.CategoryResponseDTO;
+import com.alkemy.ong.model.response.pagination.CustomPage;
 import com.alkemy.ong.repository.CategoryRepository;
 import com.alkemy.ong.service.CategoryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,4 +58,9 @@ public class CategoryServiceImpl implements CategoryService {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public CustomPage<CategoryResponseDTO> getCategoriesPageable(Pageable pageRequest) {
+        return new CustomPage<>(categoryRepository.findAll(pageRequest)
+                .map(categoryMapper::categoryEntity2DTO));
+    }
 }


### PR DESCRIPTION
Jira:  [https://alkemy-labs.atlassian.net/browse/OT111-80](https://alkemy-labs.atlassian.net/browse/OT111-80)

### Reporte:

- Se crearon las clases CustomPage y CustomPageable para entregar la response con formato Page adaptada a lo solicitado:
La response entrega una lista de categorías paginadas de a 10 resultados, ademas del numero de paginas, numero de elementos,  total de elementos y total de paginas.
-  Se creo el metodo getCategoriesPageable en el servicio para obtener la CustomPage desde el repositorio con los datos de paginación.
- Se modifico el metodo del endpoint GET /categories para agregar paginación.
- Se agregaron anotaciones y descripciones en el endpoint para la documentación de Swagger.

### Evidencia de correcto funcionamiento:
<img width="612" alt="image" src="https://user-images.githubusercontent.com/87948501/146498221-1fda9736-b18a-466c-87a3-606ad76c491d.png">
