### PR TITLE
AWSController updated with consumes and produces

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/AWSBucketController.java
+++ b/src/main/java/com/alkemy/ong/controller/AWSBucketController.java
@@ -4,6 +4,7 @@ import com.alkemy.ong.model.response.AWSResponseDTO;
 import com.alkemy.ong.service.AWSService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +19,8 @@ public class AWSBucketController {
     @Autowired
     private AWSService awsService;
 
-    @PostMapping("/upload")
+    @PostMapping(value = "/upload", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE},
+            produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<AWSResponseDTO> uploadFile(@RequestPart(value = "file")MultipartFile file) {
         AWSResponseDTO response = awsService.uploadFile(file);
         return ResponseEntity.status(HttpStatus.OK).body(response);


### PR DESCRIPTION
Se agrega anotación "consumes y produces" al PostMapping para poder utilizar la carga de archivos en Swagger